### PR TITLE
Older browsers after tests adjustments

### DIFF
--- a/dist/templates/banner-cookie-declaration-consent-iab/banner-cookie-declaration-consent-iab.html
+++ b/dist/templates/banner-cookie-declaration-consent-iab/banner-cookie-declaration-consent-iab.html
@@ -88,7 +88,7 @@
   function showDescription(id) {
     var categoryNames = document.getElementsByClassName('coi-consent-banner__category-name');
     var descriptions = document.getElementsByClassName('coi-consent-banner__description-container');
-    var category = document.getElementById(id);
+    var category = document.getElementById('coi-category-' + id);
     var descriptionContainer = document.getElementById('coi-consent-banner__description-container-' + id);
     var description = document.getElementById('coi-description-' + id);
     var foundCookiesTable = document.getElementById('coi-found-cookies-' + id);
@@ -164,19 +164,19 @@
             <div class="coi-consent-banner__categories-wrapper active" id="coiConsentBannerCategoriesWrapper">
                 {{#each cookie_categories}}
                 <div class="coi-consent-banner__category-container">
-                    <div class="coi-consent-banner__name-container">
-              <span onclick="showDescription(this.id);" class="coi-consent-banner__category-name" id="{{this.cookie_type_label}}">
-                {{{this.cookie_type_name}}}</span>
+                    <div class="coi-consent-banner__name-container" id="{{this.cookie_type_label}}" onclick="showDescription(this.id);">
+                      <span class="coi-consent-banner__category-name" id="coi-category-{{this.cookie_type_label}}">
+                        {{{this.cookie_type_name}}}</span>
                         {{#unless this.is_necessary}}
-                        {{#unless this.is_unclassified}}
-                        <div class="coi-consent-banner__switch-container" id="switch-{{this.cookie_type_label}}">
-                            <label class="coi-consent-banner__switch">
-                                <input type="checkbox" class="coi-consent-banner__switch-checkbox" name="{{this.cookie_type_label}}" id="switch-{{this.cookie_type_label}}-slider"
-                                       onclick="CookieInformation.changeCategoryConsentDecision('{{this.cookie_type_label}}');">
-                                <span class="coi-consent-banner__slider"></span>
-                            </label>
-                        </div>
-                        {{/unless}}
+                            {{#unless this.is_unclassified}}
+                                <div class="coi-consent-banner__switch-container" id="switch-{{this.cookie_type_label}}">
+                                    <label class="coi-consent-banner__switch">
+                                        <input type="checkbox" class="coi-consent-banner__switch-checkbox" name="{{this.cookie_type_label}}" id="switch-{{this.cookie_type_label}}-slider"
+                                               onclick="CookieInformation.changeCategoryConsentDecision('{{this.cookie_type_label}}');">
+                                        <span class="coi-consent-banner__slider"></span>
+                                    </label>
+                                </div>
+                            {{/unless}}
                         {{/unless}}
                     </div>
                     <div class="coi-consent-banner__description-container" id="coi-consent-banner__description-container-{{this.cookie_type_label}}">

--- a/dist/templates/banner-cookie-declaration-consent-iab/banner-cookie-declaration-consent-iab.html
+++ b/dist/templates/banner-cookie-declaration-consent-iab/banner-cookie-declaration-consent-iab.html
@@ -93,6 +93,8 @@
     var description = document.getElementById('coi-description-' + id);
     var foundCookiesTable = document.getElementById('coi-found-cookies-' + id);
     var descriptionContainerHeight = description.scrollHeight + foundCookiesTable.scrollHeight + 'px';
+    var isMobile = (navigator.userAgent.indexOf("MSIE") >= 0) ? '' : window.matchMedia('(max-width: 760px)').matches;
+
 
     for (var i = 0; i < categoryNames.length; i++) {
       removeClass(categoryNames[i], 'active');
@@ -110,6 +112,11 @@
       descriptionContainer.style.maxHeight = descriptionContainerHeight;
     }
     else {
+      if (!isMobile) {
+        addClass(category, 'active');
+        addClass(descriptionContainer, 'active');
+        descriptionContainer.style.maxHeight = descriptionContainerHeight;
+      }
       currentCategory = '';
     }
   }

--- a/dist/templates/banner-cookie-declaration-consent/banner-cookie-declaration-consent.html
+++ b/dist/templates/banner-cookie-declaration-consent/banner-cookie-declaration-consent.html
@@ -86,7 +86,7 @@
   function showDescription(id) {
     var categoryNames = document.getElementsByClassName('coi-consent-banner__category-name');
     var descriptions = document.getElementsByClassName('coi-consent-banner__description-container');
-    var category = document.getElementById(id);
+    var category = document.getElementById('coi-category-' + id);
     var descriptionContainer = document.getElementById('coi-consent-banner__description-container-' + id);
     var description = document.getElementById('coi-description-' + id);
     var foundCookiesTable = document.getElementById('coi-found-cookies-' + id);
@@ -160,8 +160,8 @@
       <div class="coi-consent-banner__categories-wrapper active" id="coiConsentBannerCategoriesWrapper">
         {{#each cookie_categories}}
           <div class="coi-consent-banner__category-container">
-            <div class="coi-consent-banner__name-container">
-              <span onclick="showDescription(this.id);" class="coi-consent-banner__category-name" id="{{this.cookie_type_label}}">
+            <div class="coi-consent-banner__name-container" id="{{this.cookie_type_label}}" onclick="showDescription(this.id);">
+              <span class="coi-consent-banner__category-name" id="coi-category-{{this.cookie_type_label}}">
                 {{{this.cookie_type_name}}}</span>
                 {{#unless this.is_necessary}}
                   {{#unless this.is_unclassified}}

--- a/dist/templates/banner-cookie-declaration-consent/banner-cookie-declaration-consent.html
+++ b/dist/templates/banner-cookie-declaration-consent/banner-cookie-declaration-consent.html
@@ -91,6 +91,8 @@
     var description = document.getElementById('coi-description-' + id);
     var foundCookiesTable = document.getElementById('coi-found-cookies-' + id);
     var descriptionContainerHeight = description.scrollHeight + foundCookiesTable.scrollHeight + 'px';
+    var isMobile = (navigator.userAgent.indexOf("MSIE") >= 0) ? '' : window.matchMedia('(max-width: 760px)').matches;
+
 
     for (var i = 0; i < categoryNames.length; i++) {
       removeClass(categoryNames[i], 'active');
@@ -108,6 +110,11 @@
       descriptionContainer.style.maxHeight = descriptionContainerHeight;
     }
     else {
+      if (!isMobile) {
+        addClass(category, 'active');
+        addClass(descriptionContainer, 'active');
+        descriptionContainer.style.maxHeight = descriptionContainerHeight;
+      }
       currentCategory = '';
     }
   }

--- a/dist/templates/banner-cookie-declaration/banner-cookie-declaration.css
+++ b/dist/templates/banner-cookie-declaration/banner-cookie-declaration.css
@@ -16,20 +16,18 @@
 
 .coi-consent-banner__indicators-container {
   display: inline-flex;
-  height: 54px;
+  min-height: 54px;
+  /*line-height: 54px;*/
   width: 100%;
   border-top: 1px solid #e0e0e0;
   border-bottom: 1px solid #e0e0e0;
-  line-height: 54px;
 }
 
 .coi-consent-banner__indicator {
-  padding: 20px 20px 18px 20px;
   color: rgba(0, 0, 0, 0.38);
   text-align: center;
   font-size: 14px;
   font-weight: 500;
-  line-height: 16px;
   text-transform: uppercase;
 }
 
@@ -223,6 +221,9 @@
 
 /*Styles active on desktop version*/
 @media screen and (min-width: 760px) {
+  .coi-consent-banner__indicator {
+    padding: 20px 20px 18px 20px;
+  }
   .coi-consent-banner__left-column {
     flex: 1 0 0;
     border-right: 1px solid #e0e0e0;
@@ -292,6 +293,12 @@
 
 /*Styles active on mobile version*/
 @media screen and (max-width: 760px) {
+  .coi-consent-banner__indicators-container {
+    justify-content: space-around;
+  }
+  .coi-consent-banner__indicator {
+    padding: 20px 0;
+  }
   .coi-consent-banner__description-container {
     width: 100%;
     max-height: 0;
@@ -324,5 +331,8 @@
     float: left;
     display: block;
     padding: 15px 0;
+  }
+  .coi-consent-banner__indicators-container {
+    line-height: 54px;
   }
 }

--- a/dist/templates/banner-cookie-declaration/banner-cookie-declaration.css
+++ b/dist/templates/banner-cookie-declaration/banner-cookie-declaration.css
@@ -17,7 +17,6 @@
 .coi-consent-banner__indicators-container {
   display: inline-flex;
   min-height: 54px;
-  /*line-height: 54px;*/
   width: 100%;
   border-top: 1px solid #e0e0e0;
   border-bottom: 1px solid #e0e0e0;

--- a/dist/templates/banner-cookie-declaration/banner-cookie-declaration.css
+++ b/dist/templates/banner-cookie-declaration/banner-cookie-declaration.css
@@ -81,6 +81,10 @@
   cursor: pointer;
 }
 
+.coi-consent-banner__name-container:hover .coi-consent-banner__category-name {
+  color: #249723;
+}
+
 .coi-consent-banner__category-name:hover {
   color: #249723;
 }

--- a/dist/templates/banner-cookie-declaration/banner-cookie-declaration.html
+++ b/dist/templates/banner-cookie-declaration/banner-cookie-declaration.html
@@ -84,6 +84,8 @@
     var description = document.getElementById('coi-description-' + id);
     var foundCookiesTable = document.getElementById('coi-found-cookies-' + id);
     var descriptionContainerHeight = description.scrollHeight + foundCookiesTable.scrollHeight + 'px';
+    var isMobile = (navigator.userAgent.indexOf("MSIE") >= 0) ? '' : window.matchMedia('(max-width: 760px)').matches;
+
 
     for (var i = 0; i < categoryNames.length; i++) {
       removeClass(categoryNames[i], 'active');
@@ -101,6 +103,11 @@
       descriptionContainer.style.maxHeight = descriptionContainerHeight;
     }
     else {
+      if (!isMobile) {
+        addClass(category, 'active');
+        addClass(descriptionContainer, 'active');
+        descriptionContainer.style.maxHeight = descriptionContainerHeight;
+      }
       currentCategory = '';
     }
   }

--- a/dist/templates/banner-cookie-declaration/banner-cookie-declaration.html
+++ b/dist/templates/banner-cookie-declaration/banner-cookie-declaration.html
@@ -79,7 +79,7 @@
   function showDescription(id) {
     var categoryNames = document.getElementsByClassName('coi-consent-banner__category-name');
     var descriptions = document.getElementsByClassName('coi-consent-banner__description-container');
-    var category = document.getElementById(id);
+    var category = document.getElementById('coi-category-' + id);
     var descriptionContainer = document.getElementById('coi-consent-banner__description-container-' + id);
     var description = document.getElementById('coi-description-' + id);
     var foundCookiesTable = document.getElementById('coi-found-cookies-' + id);
@@ -152,8 +152,8 @@
       <div class="coi-consent-banner__categories-wrapper active" id="coiConsentBannerCategoriesWrapper">
         {{#each cookie_categories}}
           <div class="coi-consent-banner__category-container">
-            <div class="coi-consent-banner__name-container">
-              <span onclick="showDescription(this.id);" class="coi-consent-banner__category-name" id="{{this.cookie_type_label}}">
+            <div class="coi-consent-banner__name-container" id="{{this.cookie_type_label}}" onclick="showDescription(this.id);">
+              <span class="coi-consent-banner__category-name" id="coi-category-{{this.cookie_type_label}}">
                 {{{this.cookie_type_name}}}</span>
             </div>
             <div class="coi-consent-banner__description-container" id="coi-consent-banner__description-container-{{this.cookie_type_label}}">


### PR DESCRIPTION
Issues fixed:
- if you clicked on currently active cookie description, it got its' active state turned off, leaving us with blank space.
- Too small area for click on description. Now the whole box that contains name and switch can be clicked.
- styling fixes for indicators(minor issues occured after changes for IE)